### PR TITLE
Change _writeCapture to not remove newlines

### DIFF
--- a/capture-console.js
+++ b/capture-console.js
@@ -38,7 +38,7 @@ class CaptureConsole {
    * @private
    */
   _writeCapture(string) {
-    this._capturedText.push(string.replace(/\n/g, ''));
+    this._capturedText.push(string);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoberoi/capture-console",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A testing helper that captures stdout and stderr",
   "main": "capture-console.js",
   "scripts": {

--- a/tests/capture-console-unit.js
+++ b/tests/capture-console-unit.js
@@ -22,7 +22,9 @@ describe('CaptureConsole', () => {
   it('should capture messages when startCapture is called', () => {
     const captureConsole = new CaptureConsole();
     const msg1 = 'OMG! It killed Kenny!';
+    const msg1after = 'OMG! It killed Kenny!\n';
     const msg2 = 'The bastard!';
+    const msg2after = 'The bastard!\n';
 
     captureConsole.startCapture();
     console.log(msg1);
@@ -32,8 +34,8 @@ describe('CaptureConsole', () => {
     captureConsole.clearCaptureText();
 
     expect(output).has.lengthOf(2);
-    expect(output[0]).equals(msg1);
-    expect(output[1]).equals(msg2);
+    expect(output[0]).equals(msg1after);
+    expect(output[1]).equals(msg2after);
   });
 
   it('should stop capturing message when stopCapture is called', () => {
@@ -54,9 +56,13 @@ describe('CaptureConsole', () => {
   it('should allow multiple start/stop capturing without clearing capture text', () => {
     const captureConsole = new CaptureConsole();
     const msg1 = 'OMG! It killed Kenny!';
+    const msg1after = 'OMG! It killed Kenny!\n';
     const msg2 = 'The bastard!';
+    const msg2after = 'The bastard!\n';
     const msg3 = 'All your base';
+    const msg3after = 'All your base\n';
     const msg4 = 'Are belong to us!';
+    const msg4after = 'Are belong to us!\n';
 
     captureConsole.startCapture();
     console.info(msg1);
@@ -70,8 +76,7 @@ describe('CaptureConsole', () => {
     captureConsole.clearCaptureText();
 
     expect(output).has.lengthOf(2);
-    expect(output[0]).equals(msg1);
-    expect(output[1]).equals(msg3);
+    expect(output[0]).equals(msg1after);
+    expect(output[1]).equals(msg3after);
   });
 });
-


### PR DESCRIPTION
_writeCapture removes newlines (`\n`) from the input string. I have removed the `string.replace(/\n/g, '')` in my single commit, replacing it simply with `string`. It is my opinion that there is no technical reason for removing newlines and it needlessly modifies the input string. For error stack traces, this makes the stack trace harder to read by shifting everything onto one line. I think if a user of this package would like to strip newlines, that should be their choice in regard to their own use case.

I have tested this change in NodeJS 10 and it works fine.

Please let me know what you think of this change!